### PR TITLE
Special formatting for proposals

### DIFF
--- a/ims-examples/ims-basic.html
+++ b/ims-examples/ims-basic.html
@@ -97,14 +97,14 @@
     <h2>
       <dfn>Foo</dfn> interface
     </h2>
-    <pre class="idl">
+    <pre class="idl"><code>
     [Exposed=Window]
     interface Foo {
       constructor();
       attribute DOMString bar;
       void doTheFoo();
     };
-    </pre>
+    </code></pre>
     <p>
       The <a>Foo</a> interface is nice. Lets you do stuff.
     </p>
@@ -124,12 +124,12 @@
       This is an example of a non-normative reference in a normative section
       [[?HTML]]
     </p>
-    <pre class="js example" title="Usage example">
+    <pre class="js example" title="Usage example"><code>
       const foo = new Foo();
       if (foo.bar === "my bar") {
         foo.doTheBar();
       }
-    </pre>
+    </code></pre>
   </section>
   <section id="logo">
     <h2>

--- a/src/ims/boilerplate.js
+++ b/src/ims/boilerplate.js
@@ -21,8 +21,13 @@ function getStatusString(conf) {
   if (conf.specType === "doc") {
     return "This is an informative IMS Global document that may be revised at any time.";
   }
+  if (conf.specType === "proposal") {
+    return "This is proposal that may be revised at any time.";
+  }
   // specStatus: See ims/config.js for known values
   switch (conf.specStatus) {
+    case "Proposal":
+      return "This document is for review and comment by IMS Contributing Members.";
     case "IMS Base Document":
       return "This document is for review and comment by IMS Contributing Members.";
     case "IMS Candidate Final":
@@ -83,7 +88,7 @@ export async function run(conf) {
 
   header.appendChild(headerTop);
 
-  if (conf.specType !== "doc") {
+  if (conf.specType !== "doc" && conf.specType !== "proposal") {
     const release = html`<div class="subtitle">
       ${conf.specStatus}<br />Version ${conf.specVersion}
     </div>`;
@@ -133,7 +138,7 @@ export async function run(conf) {
       </tbody>
     </table>`;
 
-  if (conf.specType !== "doc") {
+  if (conf.specType !== "doc" && conf.specType !== "proposal") {
     header.appendChild(versionTable);
   } else {
     const genericDocTable = html` <table
@@ -155,110 +160,124 @@ export async function run(conf) {
     header.appendChild(genericDocTable);
   }
 
-  const ipr = html`<div id="ipr">
-    <h2>IPR and Distribution Notice</h2>
-    <p>
-      Recipients of this document are requested to submit, with their comments,
-      notification of any relevant patent claims or other intellectual property
-      rights of which they may be aware that might be infringed by any
-      implementation of the specification set forth in this document, and to
-      provide supporting documentation.
-    </p>
-    <p>
-      IMS takes no position regarding the validity or scope of any intellectual
-      property or other rights that might be claimed to pertain to the
-      implementation or use of the technology described in this document or the
-      extent to which any license under such rights might or might not be
-      available; neither does it represent that it has made any effort to
-      identify any such rights. Information on IMS's procedures with respect to
-      rights in IMS specifications can be found at the IMS Intellectual Property
-      Rights web page:
-      <a href="http://www.imsglobal.org/ipr/imsipr_policyFinal.pdf">
-        http://www.imsglobal.org/ipr/imsipr_policyFinal.pdf</a
-      >.
-    </p>
-  </div>`;
-  header.appendChild(ipr);
+  if (conf.specType === "proposal") {
+    const proposal = html`<div id="proposal">
+      <h2>Proposals</h2>
+      <p>
+        Proposals are made available for the purposes of Project Group / Task
+        only and should not be distributed outside of the IMS Contributing
+        Membership without the express written consent of IMS GLC. Provision of
+        any work documents outside of the project group/ task force will revoke
+        all privileges as an Invited Guest. Any documents provided
+        non-participants will be done by IMS GLC only on the IMS GLC public
+        website when the documents become publicly available.
+      </p>
+    </div>`;
+    header.appendChild(proposal);
+  } else {
+    const ipr = html`<div id="ipr">
+      <h2>IPR and Distribution Notice</h2>
+      <p>
+        Recipients of this document are requested to submit, with their
+        comments, notification of any relevant patent claims or other
+        intellectual property rights of which they may be aware that might be
+        infringed by any implementation of the specification set forth in this
+        document, and to provide supporting documentation.
+      </p>
+      <p>
+        IMS takes no position regarding the validity or scope of any
+        intellectual property or other rights that might be claimed to pertain
+        implementation or use of the technology described in this document or the
+        extent to which any license under such rights might or might not be
+        available; neither does it represent that it has made any effort to
+        identify any such rights. Information on IMS's procedures with respect to
+        rights in IMS specifications can be found at the IMS Intellectual Property
+        Rights web page:
+        <a href="http://www.imsglobal.org/ipr/imsipr_policyFinal.pdf">
+          http://www.imsglobal.org/ipr/imsipr_policyFinal.pdf
+        </a>.
+      </p>
+    </div>`;
+    header.appendChild(ipr);
 
-  if (conf.iprs) {
-    header.appendChild(html`<p>
-      The following participating organizations have made explicit license
-      commitments to this specification:
-    </p>`);
-    let iprTable = `<table>
-      <thead>
-        <tr>
-          <th>Org name</th>
-          <th>Date election made</th>
-          <th>Necessary claims</th>
-          <th>Type</th>
-        </th>
-      </thead>
-      <tbody>`;
-    conf.iprs.forEach(element => {
-      iprTable += `<tr>
-          <td>${element.company}</td>
-          <td>${element.electionDate}</td>
-          <td>${element.necessaryClaims}</td>
-          <td>${element.type}</td>
-        </tr>`;
-    });
-    iprTable += `</tbody></table>`;
-    const iprTableElement = document.createElement("div");
-    iprTableElement.innerHTML = iprTable;
-    header.appendChild(iprTableElement);
+    if (conf.iprs) {
+      header.appendChild(html`<p>
+        The following participating organizations have made explicit license
+        commitments to this specification:
+      </p>`);
+      let iprTable = `<table>
+        <thead>
+          <tr>
+            <th>Org name</th>
+            <th>Date election made</th>
+            <th>Necessary claims</th>
+            <th>Type</th>
+          </th>
+        </thead>
+        <tbody>`;
+      conf.iprs.forEach(element => {
+        iprTable += `<tr>
+            <td>${element.company}</td>
+            <td>${element.electionDate}</td>
+            <td>${element.necessaryClaims}</td>
+            <td>${element.type}</td>
+          </tr>`;
+      });
+      iprTable += `</tbody></table>`;
+      const iprTableElement = document.createElement("div");
+      iprTableElement.innerHTML = iprTable;
+      header.appendChild(iprTableElement);
+    }
+
+    const disclosure = html` <div id="disclosure">
+      <p>
+        Use of this specification to develop products or services is governed by
+        the license with IMS found on the IMS website:
+        <a href="http://www.imsglobal.org/speclicense.html">
+          http://www.imsglobal.org/speclicense.html</a
+        >.
+      </p>
+      <p>
+        Permission is granted to all parties to use excerpts from this document as
+        needed in producing requests for proposals.
+      </p>
+      <p>
+        The limited permissions granted above are perpetual and will not be
+        revoked by IMS or its successors or assigns.
+      </p>
+      <p>
+        THIS SPECIFICATION IS BEING OFFERED WITHOUT ANY WARRANTY WHATSOEVER, AND
+        IN PARTICULAR, ANY WARRANTY OF NONINFRINGEMENT IS EXPRESSLY DISCLAIMED.
+        ANY USE OF THIS SPECIFICATION SHALL BE MADE ENTIRELY AT THE IMPLEMENTER'S
+        OWN RISK, AND NEITHER THE CONSORTIUM, NOR ANY OF ITS MEMBERS OR
+        SUBMITTERS, SHALL HAVE ANY LIABILITY WHATSOEVER TO ANY IMPLEMENTER OR
+        THIRD PARTY FOR ANY DAMAGES OF ANY NATURE WHATSOEVER, DIRECTLY OR
+        INDIRECTLY, ARISING FROM THE USE OF THIS SPECIFICATION.
+      </p>
+      <p>
+        Public contributions, comments and questions can be posted here:
+        <a href="http://www.imsglobal.org/forums/ims-glc-public-forums-and-resources">
+          http://www.imsglobal.org/forums/ims-glc-public-forums-and-resources
+        </a>.
+      </p>
+    </div>`;
+    header.appendChild(disclosure);
+
+    const copyright = html`<div id="cpr">
+      <p>
+        © ${new Date().getFullYear()} IMS Global Learning Consortium, Inc. All
+        Rights Reserved.
+      </p>
+      <p>
+        Trademark information:
+        <a href="http://www.imsglobal.org/copyright.html"
+          >http://www.imsglobal.org/copyright.html
+        </a>
+      </p>
+    </div>`;
+
+    header.appendChild(copyright);
   }
-
-  const disclosure = html` <div id="disclosure">
-    <p>
-      Use of this specification to develop products or services is governed by
-      the license with IMS found on the IMS website:
-      <a href="http://www.imsglobal.org/speclicense.html">
-        http://www.imsglobal.org/speclicense.html</a
-      >.
-    </p>
-    <p>
-      Permission is granted to all parties to use excerpts from this document as
-      needed in producing requests for proposals.
-    </p>
-    <p>
-      The limited permissions granted above are perpetual and will not be
-      revoked by IMS or its successors or assigns.
-    </p>
-    <p>
-      THIS SPECIFICATION IS BEING OFFERED WITHOUT ANY WARRANTY WHATSOEVER, AND
-      IN PARTICULAR, ANY WARRANTY OF NONINFRINGEMENT IS EXPRESSLY DISCLAIMED.
-      ANY USE OF THIS SPECIFICATION SHALL BE MADE ENTIRELY AT THE IMPLEMENTER'S
-      OWN RISK, AND NEITHER THE CONSORTIUM, NOR ANY OF ITS MEMBERS OR
-      SUBMITTERS, SHALL HAVE ANY LIABILITY WHATSOEVER TO ANY IMPLEMENTER OR
-      THIRD PARTY FOR ANY DAMAGES OF ANY NATURE WHATSOEVER, DIRECTLY OR
-      INDIRECTLY, ARISING FROM THE USE OF THIS SPECIFICATION.
-    </p>
-    <p>
-      Public contributions, comments and questions can be posted here:
-      <a
-        href="http://www.imsglobal.org/forums/ims-glc-public-forums-and-resources"
-      >
-        http://www.imsglobal.org/forums/ims-glc-public-forums-and-resources</a
-      >.
-    </p>
-  </div>`;
-  header.appendChild(disclosure);
-
-  const copyright = html`<div id="cpr">
-    <p>
-      © ${new Date().getFullYear()} IMS Global Learning Consortium, Inc. All
-      Rights Reserved.
-    </p>
-    <p>
-      Trademark information:
-      <a href="http://www.imsglobal.org/copyright.html"
-        >http://www.imsglobal.org/copyright.html</a
-      >
-    </p>
-  </div>`;
-
-  header.appendChild(copyright);
 
   if (body.firstChild) {
     body.insertBefore(header, body.firstChild);

--- a/src/ims/boilerplate.js
+++ b/src/ims/boilerplate.js
@@ -22,7 +22,7 @@ function getStatusString(conf) {
     return "This is an informative IMS Global document that may be revised at any time.";
   }
   if (conf.specType === "proposal") {
-    return "This is proposal that may be revised at any time.";
+    return "This is a proposal that may be revised at any time.";
   }
   // specStatus: See ims/config.js for known values
   switch (conf.specStatus) {

--- a/src/ims/config.js
+++ b/src/ims/config.js
@@ -54,7 +54,7 @@ export async function run(conf) {
     conf.specType = "spec";
   }
 
-  if (conf.specType === "doc") {
+  if (conf.specType === "doc" || conf.specType === "proposal") {
     return;
   }
 
@@ -82,6 +82,7 @@ export async function run(conf) {
     "IMS Candidate Final",
     "IMS Candidate Final Public",
     "IMS Final Release",
+    "Proposal",
   ];
   if (statusValues.indexOf(conf.specStatus) == -1) {
     pub(


### PR DESCRIPTION
New `specType: "proposal"` formatting based on `specType: "doc"` to make the resulting document un-spec-like.

- Unique status text
- Most boilerplate content omitted
- New "Proposal" boilerplate section

[Open Badges 2.0 VC Packaging Extension 0.1 undefined.pdf](https://github.com/IMSGlobal/respec/files/6831393/Open.Badges.2.0.VC.Packaging.Extension.0.1.undefined.pdf)
